### PR TITLE
dhcp6relay: Need a non-zero default hop count limit

### DIFF
--- a/main.c
+++ b/main.c
@@ -40,6 +40,7 @@ main(int argc, char *argv[])
 			this_ifc = &ifc[nifc++];
 			memset(this_ifc, 0, sizeof *this_ifc);
 			this_ifc->name = optarg;
+			this_ifc->trust_hops = 10;
 			this_ifc->side = ch == 'i' ? CLIENT : SERVER;
 			break;
 		case 'v':


### PR DESCRIPTION
Otherwise `dhcp_wrap` fails to forward:

```
...
		case DHCP_RELAY_FORW:
			if (pkt->datalen < 2)
				return -1; /* malformed */
			if (pkt->data[1/*hop_count*/] >= ifc->trust_hops) {
				verbose(
				    "%s: too many nested forwards (%u) from %s. %d %d\n",
...
```