### PR TITLE
dhcp6relay: fixes for dhcp_unwrap option walking

### DIFF
--- a/loop.c
+++ b/loop.c
@@ -115,7 +115,7 @@ close:
 				    ifc[i].name, pkt_lladdr(&pkt));
 				unsigned j;
 				for (j = 0; j < nifc; j++)
-					if (ifc[j].side == SERVER &&
+					if (ifc[j].side == CLIENT &&
 					    pfd[j].fd != -1 &&
 					    strncmp(ifc[j].name, name,
 					        IFNAMSIZ) == 0)


### PR DESCRIPTION
- Needs to skip the header fields
- Needs to increment by `opt.len`
- Need to look for a CLIENT interface for server-client relay to work