### PR TITLE
dhcp6relay: minimise libc dependency for uClibc purposes

### DIFF
--- a/dhcp.h
+++ b/dhcp.h
@@ -1,4 +1,6 @@
-#include <net/if.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <linux/if.h>
 
 struct ifc;
 struct pkt;

--- a/loop.c
+++ b/loop.c
@@ -3,7 +3,7 @@
 #include <ifaddrs.h>
 #include <unistd.h>
 
-#include <net/if.h>
+#include <linux/if.h>
 #include <netinet/in.h>
 #include <sys/poll.h>
 #include <sys/types.h>

--- a/pkt.h
+++ b/pkt.h
@@ -10,7 +10,9 @@
  */
 
 #include <string.h>
+#include <sys/types.h>
 #include <sys/socket.h>
+#include <linux/if.h>
 #include <net/ethernet.h>
 #include <netinet/udp.h>
 #include <netinet/ip6.h>


### PR DESCRIPTION
Resolve compilation problems cross-compiling to uClibc.

Various `net/if.h` declarations seem to be in conflict with the kernel headers.